### PR TITLE
Improve help jump links colors

### DIFF
--- a/colors/plain.vim
+++ b/colors/plain.vim
@@ -186,6 +186,10 @@ else
   call s:h("SpellLocal",  {"cterm": "underline", "fg": s:dark_green})
 endif
 
+""" Help
+hi link helpHyperTextEntry Title
+hi link helpHyperTextJump  String
+
 """ StatusLine
 
 call s:h("StatusLine",        {"gui": "underline", "bg": s:bg, "fg": s:status_line})


### PR DESCRIPTION
It's really hard to find jump links in help files currently, so I made this minor tweak to improve this.

Left is before (current), right is after

<img width="1661" alt="screen shot 2018-05-06 at 15 09 53" src="https://user-images.githubusercontent.com/63876/39673596-a6b9717c-513f-11e8-845a-602efeb5fa2a.png">
