### PR TITLE
remove unnecessary backgrounds

### DIFF
--- a/colors/plain.vim
+++ b/colors/plain.vim
@@ -99,12 +99,12 @@ function! s:h(group, style)
     \ "cterm="   (has_key(a:style, "cterm") ? a:style.cterm    : "NONE")
 endfunction
 
-call s:h("Normal",        {"bg": s:bg, "fg": s:norm})
-call s:h("Noise",         {"bg": s:bg, "fg": s:norm_subtle})
+call s:h("Normal",        {"fg": s:norm})
+call s:h("Noise",         {"fg": s:norm_subtle})
 call s:h("Cursor",        {"bg": s:blue, "fg": s:norm})
 call s:h("Comment",       {"fg": s:comment, "gui": "italic"})
 
-call s:h("Constant",      {"bg": s:bg, "fg": s:constant})
+call s:h("Constant",      {"fg": s:constant})
 hi! link Character        Constant
 hi! link Number           Constant
 hi! link Boolean          Constant
@@ -116,7 +116,7 @@ hi! link Identifier       Normal
 hi! link Function         Identifier
 
 "hi! link Statement        Normal
-call s:h("Statement",     {"bg": s:bg, "fg": s:norm, "gui": "bold"})
+call s:h("Statement",     {"fg": s:norm, "gui": "bold"})
 hi! link Conditonal       Statement
 hi! link Repeat           Statement
 hi! link Label            Statement
@@ -242,7 +242,7 @@ hi link jsGlobalNodeObjects Normal
 hi link jsArrowFunction Noise
 hi link StorageClass Statement
 
-call s:h("xmlTag", {"bg": s:bg, "fg": s:constant})
+call s:h("xmlTag", {"fg": s:constant})
 hi link xmlTagName xmlTag
 hi link xmlEndTag xmlTag
 hi link xmlAttrib xmlTag
@@ -261,3 +261,8 @@ hi link markdownHeadingDelimiter Constant
 
 hi link yamlBlockMappingKey Statement
 hi link pythonOperator Statement
+
+" this is required to highlight Reason
+hi link rustEnumVariant Constant
+hi link rustTrait Statement
+hi link rustModPath Statement


### PR DESCRIPTION
I have updated NeoVim recently and started to experience the following problem:

<img width="751" alt="screen shot 2018-08-24 at 11 18 10" src="https://user-images.githubusercontent.com/527503/44576810-d295e180-a78f-11e8-967e-74718fee192a.png">

I.e. if you look at the selected line, you can see that some keywords or constants override the background, which looks quite ugly. So, I remove unnecessary `bg` properties throughout the `plain.vim`. Also, I've added a few `hi` statements to the end for Reason highlighting. Here is the result:

<img width="751" alt="screen shot 2018-08-24 at 11 15 56" src="https://user-images.githubusercontent.com/527503/44576946-21dc1200-a790-11e8-877f-2dbd963a6ebd.png">
